### PR TITLE
FIX: the regexen to identify versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,16 @@
-0.17 2023-11-11T12:38:33+01:00 (908076a => Abe Timmerman)
+0.17_00 2023-11-16T17:39:06+01:00 (f646cf4 => Abe Timmerman)
+ - (Abe Timmerman, Thu, 16 Nov 2023 17:39:06 +0100) Autocommit for
+   distribution V 0.17_00 (test)
+
+0.17 2023-11-11T12:38:33+01:00 (0ddb542 => Abe Timmerman)
  - (Abe Timmerman, Sat, 11 Nov 2023 12:38:33 +0100) Autocommit for
    distribution V 0.17 (minor)
+ - (Abe Timmerman, Thu, 16 Nov 2023 16:46:18 +0100) FIX: the regexen to
+   identify versions
+ -     I broke V with the (changed/new) regexen in v0.17.
+ -     Changed the regexen and added some more examples/tests.
+ - (Abe Timmerman, Thu, 16 Nov 2023 17:38:47 +0100) Add new files to
+   MANIFEST
 
 0.16_03 2023-11-10T19:40:30+01:00 (b8a9cbe => Abe Timmerman)
  - (Abe Timmerman, Fri, 10 Nov 2023 19:40:30 +0100) Autocommit for

--- a/Changes
+++ b/Changes
@@ -1,6 +1,14 @@
-0.17_00 2023-11-16T17:39:06+01:00 (f646cf4 => Abe Timmerman)
+0.17_01 2023-11-21T12:10:53+01:00 (205fb7a => Abe Timmerman)
+ - (Abe Timmerman, Tue, 21 Nov 2023 12:10:53 +0100) Autocommit for
+   distribution V 0.17_01 (test)
+
+0.17_00 2023-11-16T17:39:06+01:00 (dc1088b => Abe Timmerman)
  - (Abe Timmerman, Thu, 16 Nov 2023 17:39:06 +0100) Autocommit for
    distribution V 0.17_00 (test)
+ - (Abe Timmerman, Tue, 21 Nov 2023 12:08:15 +0100) Show only
+   packages/classes with a defined version
+ -     Some code clean-up
+ -     Add test for packages failing under 0.17
 
 0.17 2023-11-11T12:38:33+01:00 (0ddb542 => Abe Timmerman)
  - (Abe Timmerman, Sat, 11 Nov 2023 12:38:33 +0100) Autocommit for

--- a/MANIFEST
+++ b/MANIFEST
@@ -28,3 +28,4 @@ xt/01-compile.t
 xt/02-pod_syntax.t
 xt/03-pod-coverage.t
 xt/04-kwalitee.t
+xt/10-packages-check.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -13,8 +13,12 @@ t/04v_version.t
 t/05_pkgwithversion.t
 t/06_multi_version.t
 t/07_class_version.t
+t/08_misleading.t
 t/lib/GH/ClassIssue1.pm
 t/lib/GH/Issue1.pm
+t/lib/Misleading.pm
+t/lib/Misleading/GetVersion.pm
+t/lib/Misleading/Version.pm
 t/lib/PkgWithVersion.pm
 t/lib/PkgWithVersion2.pm
 t/lib/V_Version.pm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **V** version 0.17
+# **V** version 0.18
 
 This module uses stolen code from
 [`Module::Info`](https://metacpan.org/pod/Module::Info) to find the location
@@ -10,6 +10,8 @@ discussion](https://www.nntp.perl.org/group/perl.perl5.porters/2002/01/msg51007.
 
 ```bash
 $ perl -MV=CPAN
+CPAN
+        /opt/homebrew/opt/perl/lib/perl5/5.38/CPAN.pm: 2.36
 ```
 
 or if you want more than one package
@@ -18,19 +20,16 @@ or if you want more than one package
 $ perl -MV=CPAN,V
 ```
 
-As of version **0.17** it will show all `package`s and `class`es in a file,
-with version if declared.
+As of version **0.17** it will show all `package`s and `class`es in a file with
+a version. (If one wants *all* packages/classes in the files, set the
+environment variable `PERL_V_SHOW_ALL`)
 
 ```bash
-$ perl -MV=Getopt::Long
-Getopt::Long
-        /opt/homebrew/opt/perl/lib/perl5/site_perl/5.38/Getopt/Long.pm:
-            Getopt::Long: 2.56
-            Getopt::Long::CallBack: 
-        /opt/homebrew/opt/perl/lib/perl5/5.38/Getopt/Long.pm:
-            Getopt::Long: 2.54
-            Getopt::Long::Parser: 
-            Getopt::Long::CallBack: 
+$ perl -MV=SOAP::Lite
+SOAP::Lite
+        /opt/homebrew/opt/perl/lib/perl5/site_perl/5.38/SOAP/Lite.pm:
+            SOAP::Lite: 1.27
+            SOAP::Client: 1.27
 ```
 
 # INSTALLATION

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libv-perl (0.17-0) stable; urgency=low
+
+    * Add new files to MANIFEST
+
+
+ -- Abe Timmerman <abeltje@cpan.org> Thu, 16 Nov 2023 17:38:47 +0100
 libv-perl (0.17) stable; urgency=low
 
     * Last minute documentation work

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+libv-perl (0.17-1) stable; urgency=low
+
+    * Show only packages/classes with a defined version
+    
+    Some code clean-up
+    Add test for packages failing under 0.17
+
+
+ -- Abe Timmerman <abeltje@cpan.org> Tue, 21 Nov 2023 12:08:15 +0100
 libv-perl (0.17-0) stable; urgency=low
 
     * Add new files to MANIFEST

--- a/lib/V.pm
+++ b/lib/V.pm
@@ -2,7 +2,7 @@ package V;
 use strict;
 
 use vars qw( $VERSION $NO_EXIT );
-$VERSION  = "0.17";
+$VERSION  = "0.17_00";
 
 $NO_EXIT ||= 0; # prevent import() from exit()ing and fall of the edge
 

--- a/lib/V.pm
+++ b/lib/V.pm
@@ -2,7 +2,7 @@ package V;
 use strict;
 
 use vars qw( $VERSION $NO_EXIT );
-$VERSION  = "0.17_00";
+$VERSION  = "0.17_01";
 
 $NO_EXIT ||= 0; # prevent import() from exit()ing and fall of the edge
 

--- a/t/08_misleading.t
+++ b/t/08_misleading.t
@@ -1,0 +1,15 @@
+#! perl -I. -w
+use t::Test::abeltje;
+
+require_ok('V');
+{
+    my $version = V::get_version('Misleading');
+    is($version, 0.42, "Misleading version");
+}
+
+{
+    my $version = V::get_version('Misleading::GetVersion');
+    is($version, 0.42, "Another misleading version");
+}
+
+abeltje_done_testing();

--- a/t/lib/Misleading.pm
+++ b/t/lib/Misleading.pm
@@ -1,0 +1,12 @@
+package Misleading;
+use vars qw< $VERSION >;
+
+$VERSION = 0.42;
+my ($major, $minor) = $VERSION =~ m/(\d+)(?:\.(\d+))?/;
+
+my %opt = ();
+%opt = (
+    package => (exists($opt{package}) ? $opt{package} : (caller)[0]),
+);
+
+1;

--- a/t/lib/Misleading/GetVersion.pm
+++ b/t/lib/Misleading/GetVersion.pm
@@ -1,0 +1,5 @@
+package Misleading::GetVersion;
+
+use Misleading::Version; our $VERSION = Misleading::Version->VERSION;
+
+1;

--- a/t/lib/Misleading/Version.pm
+++ b/t/lib/Misleading/Version.pm
@@ -1,0 +1,5 @@
+package Misleading::Version;
+
+our $VERSION = 0.42;
+
+1;

--- a/xt/10-packages-check.t
+++ b/xt/10-packages-check.t
@@ -1,0 +1,45 @@
+#! perl -I. -w
+use t::Test::abeltje;
+
+# These gave problems in 0.17, so keep them around
+# No::Package is to test a Not Installed thing
+my @test_cases = qw<
+    CPAN::Reporter
+    DBI
+    Parse::RecDescent
+    SOAP::Lite
+    Sub::Exporter
+    Sub::Quote
+    XML::DOM
+    XML::LibXML
+    XML::Twig
+    No::Package
+>;
+my %multi_version = (
+    'SOAP::Lite' => [qw< SOAP::Lite SOAP::Client >],
+);
+
+for my $test (@test_cases) {
+    my $stdout = qx{"$^X" "-Ilib", "-MV=$test"};
+    SKIP: {
+        skip("Package not installed: $test", 1)
+            if $stdout =~ m{^\tNot found}m;
+        if (exists($multi_version{$test})) {
+            my $pkgs = join("\n", map { "\t    $_: .+" } @{$multi_version{$test}});
+            like(
+                $stdout,
+                qr{^$test\n\t.+:\n$pkgs},
+                "found version for $test"
+            );
+        }
+        else {
+            like(
+                $stdout,
+                qr{^$test\n\s+.+: .+},
+                "found version for $test"
+            );
+        }
+    }
+}
+
+abeltje_done_testing();


### PR DESCRIPTION
I broke V with the (changed/new) regexen in v0.17. Changed the regexen and added some more examples/tests.
See [issue](https://github.com/abeltje/V/issues/2)